### PR TITLE
UIDExpunge: Fix issues when channel is nil

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,7 +28,9 @@ func (c *Client) SupportUidPlus() (bool, error) {
 // set and have a UID that is included in the specified sequence set from the
 // currently selected mailbox.
 func (c *Client) UidExpunge(seqSet *imap.SeqSet, ch chan uint32) error {
-	defer close(ch)
+	if ch != nil {
+		defer close(ch)
+	}
 
 	if c.c.State() != imap.SelectedState {
 		return client.ErrNoMailboxSelected

--- a/client.go
+++ b/client.go
@@ -38,7 +38,7 @@ func (c *Client) UidExpunge(seqSet *imap.SeqSet, ch chan uint32) error {
 		Cmd: &ExpungeCommand{SeqSet: seqSet},
 	}
 
-	var res *responses.Expunge
+	var res responses.Handler
 	if ch != nil {
 		res = &responses.Expunge{SeqNums: ch}
 	}


### PR DESCRIPTION
Fixes #5 and an additional panic that occurs when trying to close a nil channel.